### PR TITLE
URL Cleanup

### DIFF
--- a/c_src/hstcp.c
+++ b/c_src/hstcp.c
@@ -3,7 +3,7 @@
 /*   The contents of this file are subject to the Mozilla Public License     */
 /*   Version 1.1 (the "License"); you may not use this file except in        */
 /*   compliance with the License. You may obtain a copy of the License at    */
-/*   http://www.mozilla.org/MPL/                                             */
+/*   https://www.mozilla.org/MPL/                                             */
 /*                                                                           */
 /*   Software distributed under the License is distributed on an "AS IS"     */
 /*   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the */

--- a/c_src/hstcp.h
+++ b/c_src/hstcp.h
@@ -3,7 +3,7 @@
 /*   The contents of this file are subject to the Mozilla Public License     */
 /*   Version 1.1 (the "License"); you may not use this file except in        */
 /*   compliance with the License. You may obtain a copy of the License at    */
-/*   http://www.mozilla.org/MPL/                                             */
+/*   https://www.mozilla.org/MPL/                                             */
 /*                                                                           */
 /*   Software distributed under the License is distributed on an "AS IS"     */
 /*   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the */

--- a/src/hstcp_drv.erl
+++ b/src/hstcp_drv.erl
@@ -1,7 +1,7 @@
 %%  The contents of this file are subject to the Mozilla Public License
 %%  Version 1.1 (the "License"); you may not use this file except in
 %%  compliance with the License. You may obtain a copy of the License
-%%  at http://www.mozilla.org/MPL/
+%%  at https://www.mozilla.org/MPL/
 %%
 %%  Software distributed under the License is distributed on an "AS IS"
 %%  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/test/src/recv_test_gen_tcp.erl
+++ b/test/src/recv_test_gen_tcp.erl
@@ -1,7 +1,7 @@
 %%  The contents of this file are subject to the Mozilla Public License
 %%  Version 1.1 (the "License"); you may not use this file except in
 %%  compliance with the License. You may obtain a copy of the License
-%%  at http://www.mozilla.org/MPL/
+%%  at https://www.mozilla.org/MPL/
 %%
 %%  Software distributed under the License is distributed on an "AS IS"
 %%  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/test/src/recv_test_hstcp.erl
+++ b/test/src/recv_test_hstcp.erl
@@ -1,7 +1,7 @@
 %%  The contents of this file are subject to the Mozilla Public License
 %%  Version 1.1 (the "License"); you may not use this file except in
 %%  compliance with the License. You may obtain a copy of the License
-%%  at http://www.mozilla.org/MPL/
+%%  at https://www.mozilla.org/MPL/
 %%
 %%  Software distributed under the License is distributed on an "AS IS"
 %%  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/test/src/test_hstcp.erl
+++ b/test/src/test_hstcp.erl
@@ -1,7 +1,7 @@
 %%  The contents of this file are subject to the Mozilla Public License
 %%  Version 1.1 (the "License"); you may not use this file except in
 %%  compliance with the License. You may obtain a copy of the License
-%%  at http://www.mozilla.org/MPL/
+%%  at https://www.mozilla.org/MPL/
 %%
 %%  Software distributed under the License is distributed on an "AS IS"
 %%  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.mozilla.org/MPL/ with 6 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).